### PR TITLE
Fixed display string of NotReady Status

### DIFF
--- a/src/Gt4Llm/GtLlmAssistantChatNotReadyStatus.class.st
+++ b/src/Gt4Llm/GtLlmAssistantChatNotReadyStatus.class.st
@@ -21,7 +21,7 @@ GtLlmAssistantChatNotReadyStatus >> createdAt [
 
 { #category : #printing }
 GtLlmAssistantChatNotReadyStatus >> gtDisplayOn: stream [
-	stream nextPutAll: 'Ready'
+	stream nextPutAll: 'Not ready'
 ]
 
 { #category : #testing }


### PR DESCRIPTION
GtLlmAssistantChatNotReadyStatus has the same display string as GtLlmAssistantChatReadyStatus...

I adapted it to the class name