### PR TITLE
Add HuggingFace provider

### DIFF
--- a/src/BaselineOfGt4HuggingFace/BaselineOfGt4HuggingFace.class.st
+++ b/src/BaselineOfGt4HuggingFace/BaselineOfGt4HuggingFace.class.st
@@ -1,0 +1,16 @@
+Class {
+    #name : #BaselineOfGt4HuggingFace,
+    #superclass : #BaselineOf,
+    #category : #BaselineOfGt4HuggingFace
+}
+
+{ #category : #baseline }
+BaselineOfGt4HuggingFace >> baseline: spec [
+    <baseline>
+    ^ spec
+        for: #common
+        do: [ spec
+                baseline: 'Gt4LlmCore'
+                    with: [ spec repository: 'github://feenkcom/gt4llm:main/src' ].
+            spec package: 'Gt4HuggingFace' with: [ spec requires: #('Gt4LlmCore') ] ]
+]

--- a/src/BaselineOfGt4HuggingFace/package.st
+++ b/src/BaselineOfGt4HuggingFace/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfGt4HuggingFace }

--- a/src/BaselineOfGt4Llm/BaselineOfGt4Llm.class.st
+++ b/src/BaselineOfGt4Llm/BaselineOfGt4Llm.class.st
@@ -18,7 +18,10 @@ BaselineOfGt4Llm >> baseline: spec [
 			spec
 				baseline: 'Gt4Anthropic'
 				with: [ spec repository: 'github://feenkcom/gt4llm:main/src' ].
-			spec
-				baseline: 'Gt4Gemini'
-				with: [ spec repository: 'github://feenkcom/gt4llm:main/src' ] ]
+                        spec
+                                baseline: 'Gt4Gemini'
+                                with: [ spec repository: 'github://feenkcom/gt4llm:main/src' ].
+                        spec
+                                baseline: 'Gt4HuggingFace'
+                                with: [ spec repository: 'github://feenkcom/gt4llm:main/src' ] ]
 ]

--- a/src/Gt4HuggingFace/GtHuggingFaceClient.class.st
+++ b/src/Gt4HuggingFace/GtHuggingFaceClient.class.st
@@ -1,0 +1,104 @@
+Class {
+    #name : #GtHuggingFaceClient,
+    #superclass : #Object,
+    #instVars : [ 'baseUrl', 'apiKey', 'history' ],
+    #classVars : [ 'ApiKeyFile' ],
+    #category : #Gt4HuggingFace
+}
+
+{ #category : #accessing }
+GtHuggingFaceClient class >> apiKeyFile [
+    ^ ApiKeyFile
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient class >> apiKeyFile: aFile [
+    ApiKeyFile := aFile
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient class >> apiKeyFileContents [
+    ^ ApiKeyFile contents trimBoth
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient class >> defaultApiKeyFile [
+    ^ FileLocator home / '.secrets' / 'hugging-face-api-key.txt'
+]
+
+{ #category : #initialization }
+GtHuggingFaceClient class >> initialize [
+    ApiKeyFile := self defaultApiKeyFile
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient class >> withApiKeyFromFile [
+    ^ self new apiKey: self apiKeyFileContents
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient >> apiKey [
+    ^ apiKey
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient >> apiKey: aKey [
+    apiKey := aKey
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient >> baseUrl [
+    ^ baseUrl
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient >> baseUrl: aUrl [
+    baseUrl := aUrl asZnUrl
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient >> defaultBaseUrl [
+    ^ 'https://api-inference.huggingface.co' asZnUrl
+]
+
+{ #category : #initialization }
+GtHuggingFaceClient >> initialize [
+    super initialize.
+    history := GtLlmRequestHistory new.
+    self baseUrl: self defaultBaseUrl
+]
+
+{ #category : #private }
+GtHuggingFaceClient >> initializeClient [
+    | client |
+    client := ZnClient new.
+    client forJsonREST.
+    client timeout: 600.
+    apiKey ifNotNil: [ client headerAt: 'Authorization' put: 'Bearer ' , apiKey ].
+    ^ client
+]
+
+{ #category : #http }
+GtHuggingFaceClient >> post: aPath withEntity: anEntity [
+    | c response |
+    c := self initializeClient.
+    c url: self baseUrl / aPath.
+    c contents: anEntity.
+    response := c post.
+    history add: c request -> c response.
+    ^ response
+]
+
+{ #category : #api }
+GtHuggingFaceClient >> generateResponseWithModel: aModel andInputs: aString [
+    ^ GtHuggingFaceGenerateResponseAPIClient new
+        client: self;
+        model: aModel;
+        inputs: aString;
+        perform
+]
+
+{ #category : #accessing }
+GtHuggingFaceClient >> history [
+    ^ history
+]

--- a/src/Gt4HuggingFace/GtHuggingFaceGenerateResponseAPIClient.class.st
+++ b/src/Gt4HuggingFace/GtHuggingFaceGenerateResponseAPIClient.class.st
@@ -1,0 +1,41 @@
+Class {
+    #name : #GtHuggingFaceGenerateResponseAPIClient,
+    #superclass : #GtLlmEndpointClient,
+    #instVars : [ 'model', 'inputs' ],
+    #category : #Gt4HuggingFace
+}
+
+{ #category : #accessing }
+GtHuggingFaceGenerateResponseAPIClient >> inputs [
+    ^ inputs
+]
+
+{ #category : #accessing }
+GtHuggingFaceGenerateResponseAPIClient >> inputs: aString [
+    inputs := aString
+]
+
+{ #category : #accessing }
+GtHuggingFaceGenerateResponseAPIClient >> model [
+    ^ model
+]
+
+{ #category : #accessing }
+GtHuggingFaceGenerateResponseAPIClient >> model: aModel [
+    model := aModel
+]
+
+{ #category : #private }
+GtHuggingFaceGenerateResponseAPIClient >> entity [
+    ^ {'inputs' -> self inputs} asDictionary
+]
+
+{ #category : #request }
+GtHuggingFaceGenerateResponseAPIClient >> request [
+    ^ self client post: ('models/' , self model) withEntity: self entity
+]
+
+{ #category : #serialization }
+GtHuggingFaceGenerateResponseAPIClient >> serializationClass [
+    ^ Dictionary
+]

--- a/src/Gt4HuggingFace/GtHuggingFaceProvider.class.st
+++ b/src/Gt4HuggingFace/GtHuggingFaceProvider.class.st
@@ -1,0 +1,72 @@
+Class {
+    #name : #GtHuggingFaceProvider,
+    #superclass : #GtLlmProvider,
+    #instVars : [ 'client', 'model', 'assistantWorking' ],
+    #category : #Gt4HuggingFace
+}
+
+{ #category : #'class initialization' }
+GtHuggingFaceProvider class >> default [
+    ^ [ self withApiKeyFromFile ]
+]
+
+{ #category : #'class initialization' }
+GtHuggingFaceProvider class >> providerName [
+    ^ 'HuggingFace'
+]
+
+{ #category : #'class initialization' }
+GtHuggingFaceProvider class >> withApiKeyFromFile [
+    ^ self new apiKey: GtHuggingFaceClient apiKeyFileContents
+]
+
+{ #category : #accessing }
+GtHuggingFaceProvider >> apiKey: aString [
+    client apiKey: aString
+]
+
+{ #category : #accessing }
+GtHuggingFaceProvider >> client [
+    ^ client
+]
+
+{ #category : #accessing }
+GtHuggingFaceProvider >> initialize [
+    super initialize.
+    model := 'bigcode/starcoder'.
+    assistantWorking := false.
+    self initializeClient
+]
+
+{ #category : #private }
+GtHuggingFaceProvider >> initializeClient [
+    client := GtHuggingFaceClient new
+]
+
+{ #category : #'provider' }
+GtHuggingFaceProvider >> sendAssistantMessage: aMessage [
+    self chat addMessage: aMessage.
+    self triggerAssistant
+]
+
+{ #category : #'provider' }
+GtHuggingFaceProvider >> status [
+    ^ assistantWorking
+        ifTrue: [ GtLlmAssistantChatWorkingStatus new ]
+        ifFalse: [ GtLlmAssistantChatReadyStatus new ]
+]
+
+{ #category : #'provider' }
+GtHuggingFaceProvider >> triggerAssistant [
+    | result |
+    self chat signalRunHasStarted.
+    assistantWorking := true.
+    result := client
+        generateResponseWithModel: model
+        andInputs: self chat messages collect: [:m | m contentText ] joinSeparatedBy: '\n'.
+    self chat addMessage: (self assistantMessageClass new
+        content: (result at: 'generated_text' ifAbsent: ['']);
+        role: 'assistant').
+    assistantWorking := false.
+    self chat signalRunIsDone
+]

--- a/src/Gt4HuggingFace/package.st
+++ b/src/Gt4HuggingFace/package.st
@@ -1,0 +1,1 @@
+Package { #name : #Gt4HuggingFace }


### PR DESCRIPTION
## Summary
- add `GtHuggingFaceClient` for HuggingFace API access
- create `GtHuggingFaceGenerateResponseAPIClient` for simple completions
- implement `GtHuggingFaceProvider` using the new client
- introduce baseline `BaselineOfGt4HuggingFace`
- load new baseline from `BaselineOfGt4Llm`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68754d6e44808325aa001c915854eaeb