### PR TITLE
Fix spec mismatch

### DIFF
--- a/src/Gt4Llm-GToolkit/GtMcpJsonRpc.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpJsonRpc.class.st
@@ -60,6 +60,11 @@ GtMcpJsonRpc >> initialize [
 	version := '2.0'
 ]
 
+{ #category : #testing }
+GtMcpJsonRpc >> isNotification [
+	^ self id isNil and: [ self method notNil ]
+]
+
 { #category : #accessing }
 GtMcpJsonRpc >> method [
 	^ method

--- a/src/Gt4Llm-GToolkit/GtMcpServer.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServer.class.st
@@ -36,6 +36,7 @@ GtMcpServer >> createAcceptedResponse [
 				code: 202;
 				reason: 'Accepted';
 				version: 'HTTP/1.1');
+		headers: (ZnHeaders new contentLength: 0);
 		entity: nil;
 		yourself
 ]

--- a/src/Gt4Llm-GToolkit/GtMcpServer.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServer.class.st
@@ -37,7 +37,7 @@ GtMcpServer >> createAcceptedResponse [
 				reason: 'Accepted';
 				version: 'HTTP/1.1');
 		headers: (ZnHeaders new contentLength: 0);
-		entity: nil;
+		entity: (ZnByteArrayEntity bytes: ByteArray new);
 		yourself
 ]
 

--- a/src/Gt4Llm-GToolkit/GtMcpServer.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServer.class.st
@@ -30,6 +30,17 @@ GtMcpServer >> addTool: aTool [
 ]
 
 { #category : #'as yet unclassified' }
+GtMcpServer >> createAcceptedResponse [
+	^ ZnResponse new
+		statusLine: (ZnStatusLine new
+				code: 202;
+				reason: 'Accepted';
+				version: 'HTTP/1.1');
+		entity: nil;
+		yourself
+]
+
+{ #category : #'as yet unclassified' }
 GtMcpServer >> dispatch: jsonRpc [
 	| camelCasedMethod |
 	camelCasedMethod := (jsonRpc method replaceAllRegex: '[^a-zA-Z]' with: ' ')
@@ -66,7 +77,11 @@ GtMcpServer >> gtHistoryFor: aView [
 		priority: 5;
 		items: [ history ];
 		column: 'Request' text: [ :each | each key entity contents ];
-		column: 'Response' text: [ :each | each value entity contents ]
+		column: 'Response'
+			text: [ :each |
+				each value entity
+					ifNil: [ '' ]
+					ifNotNil: [ :anEntity | anEntity contents ] ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -168,9 +183,11 @@ GtMcpServer >> handleRequest: request [
 			self isDebug ifTrue: [ anError signal ].
 			^ ZnResponse badRequest: request ].
 
-	response := (GtMcpJsonRpc new
-			id: jsonRpc id;
-			result: jsonRpcResult) asZnResponse.
+	response := jsonRpc isNotification
+			ifTrue: [ self createAcceptedResponse ]
+			ifFalse: [ (GtMcpJsonRpc new
+					id: jsonRpc id;
+					result: jsonRpcResult) asZnResponse ].
 
 	history add: request -> response.
 

--- a/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
@@ -5,6 +5,28 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
+GtMcpServerExamples >> jsonRpcNotificationDetection [
+	<gtExample>
+	| notification request |
+	notification := GtMcpJsonRpc
+			on: {'jsonrpc' -> '2.0'.
+					'method' -> 'tools/list'} asDictionary.
+
+	self assert: notification id isNil.
+	self assert: notification isNotification.
+
+	request := GtMcpJsonRpc
+			on: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
+					'method' -> 'tools/list'} asDictionary.
+
+	self assert: request id equals: 1.
+	self assert: request isNotification not.
+
+	^ notification
+]
+
+{ #category : #'as yet unclassified' }
 GtMcpServerExamples >> serverRequestWithEntity: anObject [
 	^ (ZnRequest post: '/')
 		entity: (ZnEntity json: (STONJSON toString: anObject))

--- a/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
@@ -139,6 +139,7 @@ GtMcpServerExamples >> serverWithInitializedNotification [
 	response := server handleRequest: request.
 
 	self assert: response statusLine code equals: 202.
+	self assert: response headers contentLength equals: 0.
 	self assert: response entity isNil.
 
 	^ server

--- a/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
@@ -22,6 +22,7 @@ GtMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'prompts/list'} asDictionary.
 	response := server handleRequest: request.
 
@@ -32,6 +33,7 @@ GtMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'prompts/get'.
 					'params' -> {'invalid' -> 1} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -40,6 +42,7 @@ GtMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 3.
 					'method' -> 'prompts/get'.
 					'params' -> {'name' -> 'notFound'} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -49,6 +52,7 @@ GtMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 4.
 					'method' -> 'prompts/get'.
 					'params'
 						-> {'name' -> 'Prompt'.
@@ -76,6 +80,7 @@ GtMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'resources/list'} asDictionary.
 	response := server handleRequest: request.
 
@@ -85,6 +90,7 @@ GtMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'resources/read'.
 					'params' -> {'invalid' -> 1} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -93,6 +99,7 @@ GtMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 3.
 					'method' -> 'resources/read'.
 					'params' -> {'uri' -> 'notFound'} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -102,6 +109,7 @@ GtMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 4.
 					'method' -> 'resources/read'.
 					'params'
 						-> {'uri' -> 'resource'}
@@ -153,6 +161,7 @@ GtMcpServerExamples >> serverWithToolWithBadRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'tools/call'.
 					'params' -> {'invalid' -> 1} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -160,6 +169,7 @@ GtMcpServerExamples >> serverWithToolWithBadRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'tools/call'.
 					'params' -> {'name' -> 'notFound'} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -176,6 +186,7 @@ GtMcpServerExamples >> serverWithToolWithSuccessfulRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'tools/list'} asDictionary.
 	response := server handleRequest: request.
 	jsonResultTools := (STONJSON fromString: response entity contents)
@@ -185,6 +196,7 @@ GtMcpServerExamples >> serverWithToolWithSuccessfulRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'tools/call'.
 					'params'
 						-> {'name' -> 'Tool'.

--- a/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
@@ -127,6 +127,24 @@ GtMcpServerExamples >> serverWithTool [
 ]
 
 { #category : #'as yet unclassified' }
+GtMcpServerExamples >> serverWithInitializedNotification [
+	<gtExample>
+	| server request response |
+	server := self simpleServer.
+
+	request := self
+			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'method' -> 'notifications/initialized'.
+					'params' -> {} asDictionary} asDictionary.
+	response := server handleRequest: request.
+
+	self assert: response statusLine code equals: 202.
+	self assert: response entity isNil.
+
+	^ server
+]
+
+{ #category : #'as yet unclassified' }
 GtMcpServerExamples >> serverWithToolWithBadRequestAndResponse [
 	<gtExample>
 	| server request response |

--- a/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
+++ b/src/Gt4Llm-GToolkit/GtMcpServerExamples.class.st
@@ -140,7 +140,7 @@ GtMcpServerExamples >> serverWithInitializedNotification [
 
 	self assert: response statusLine code equals: 202.
 	self assert: response headers contentLength equals: 0.
-	self assert: response entity isNil.
+	self assert: response entity contentLength equals: 0.
 
 	^ server
 ]

--- a/src/Gt4LlmCore/GtLMcpJsonRpc.class.st
+++ b/src/Gt4LlmCore/GtLMcpJsonRpc.class.st
@@ -60,6 +60,11 @@ GtLMcpJsonRpc >> initialize [
 	version := '2.0'
 ]
 
+{ #category : #testing }
+GtLMcpJsonRpc >> isNotification [
+	^ self id isNil and: [ self method notNil ]
+]
+
 { #category : #accessing }
 GtLMcpJsonRpc >> method [
 	^ method

--- a/src/Gt4LlmCore/GtLMcpServer.class.st
+++ b/src/Gt4LlmCore/GtLMcpServer.class.st
@@ -109,10 +109,23 @@ GtLMcpServer >> createBadRequestResponseForError: anError fromRequest: request [
 ]
 
 { #category : #public }
+GtLMcpServer >> createAcceptedResponse [
+	^ ZnResponse new
+		statusLine: (ZnStatusLine new
+				code: 202;
+				reason: 'Accepted';
+				version: 'HTTP/1.1');
+		entity: nil;
+		yourself
+]
+
+{ #category : #public }
 GtLMcpServer >> createResponseForResult: aJsonRpcResult forRpc: aJsonRpc [
-	^((GtLMcpJsonRpc new)
-				id: aJsonRpc id;
-				result: aJsonRpcResult) asZnResponse.
+	aJsonRpc isNotification ifTrue: [ ^ self createAcceptedResponse ].
+
+	^ ((GtLMcpJsonRpc new)
+		id: aJsonRpc id;
+		result: aJsonRpcResult) asZnResponse
 ]
 
 { #category : #utils }

--- a/src/Gt4LlmCore/GtLMcpServer.class.st
+++ b/src/Gt4LlmCore/GtLMcpServer.class.st
@@ -116,7 +116,7 @@ GtLMcpServer >> createAcceptedResponse [
 				reason: 'Accepted';
 				version: 'HTTP/1.1');
 		headers: (ZnHeaders new contentLength: 0);
-		entity: nil;
+		entity: (ZnByteArrayEntity bytes: ByteArray new);
 		yourself
 ]
 

--- a/src/Gt4LlmCore/GtLMcpServer.class.st
+++ b/src/Gt4LlmCore/GtLMcpServer.class.st
@@ -115,6 +115,7 @@ GtLMcpServer >> createAcceptedResponse [
 				code: 202;
 				reason: 'Accepted';
 				version: 'HTTP/1.1');
+		headers: (ZnHeaders new contentLength: 0);
 		entity: nil;
 		yourself
 ]

--- a/src/Gt4LlmCore/GtLMcpServerExamples.class.st
+++ b/src/Gt4LlmCore/GtLMcpServerExamples.class.st
@@ -17,6 +17,28 @@ GtLMcpServerExamples >> createBadRequestWithMessage: aMessage for: aRequest [
 ]
 
 { #category : #examples }
+GtLMcpServerExamples >> jsonRpcNotificationDetection [
+	<gtExample>
+	| notification request |
+	notification := GtLMcpJsonRpc
+			on: {'jsonrpc' -> '2.0'.
+					'method' -> 'tools/list'} asDictionary.
+
+	self assert: notification id isNil.
+	self assert: notification isNotification.
+
+	request := GtLMcpJsonRpc
+			on: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
+					'method' -> 'tools/list'} asDictionary.
+
+	self assert: request id equals: 1.
+	self assert: request isNotification not.
+
+	^ notification
+]
+
+{ #category : #examples }
 GtLMcpServerExamples >> serverRequestWithEntity: anObject [
 	^ (ZnRequest post: '/')
 		entity: (ZnEntity json: (STONJSON toString: anObject))

--- a/src/Gt4LlmCore/GtLMcpServerExamples.class.st
+++ b/src/Gt4LlmCore/GtLMcpServerExamples.class.st
@@ -161,6 +161,24 @@ GtLMcpServerExamples >> serverWithTool [
 ]
 
 { #category : #examples }
+GtLMcpServerExamples >> serverWithInitializedNotification [
+	<gtExample>
+	| server request response |
+	server := self simpleServer.
+
+	request := self
+			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'method' -> 'notifications/initialized'.
+					'params' -> {} asDictionary} asDictionary.
+	response := server handleRequest: request.
+
+	self assert: response statusLine code equals: 202.
+	self assert: response entity isNil.
+
+	^ server
+]
+
+{ #category : #examples }
 GtLMcpServerExamples >> serverWithToolWithBadRequestAndResponse [
 	<gtExample>
 	| server request response |

--- a/src/Gt4LlmCore/GtLMcpServerExamples.class.st
+++ b/src/Gt4LlmCore/GtLMcpServerExamples.class.st
@@ -174,7 +174,7 @@ GtLMcpServerExamples >> serverWithInitializedNotification [
 
 	self assert: response statusLine code equals: 202.
 	self assert: response headers contentLength equals: 0.
-	self assert: response entity isNil.
+	self assert: response entity contentLength equals: 0.
 
 	^ server
 ]

--- a/src/Gt4LlmCore/GtLMcpServerExamples.class.st
+++ b/src/Gt4LlmCore/GtLMcpServerExamples.class.st
@@ -173,6 +173,7 @@ GtLMcpServerExamples >> serverWithInitializedNotification [
 	response := server handleRequest: request.
 
 	self assert: response statusLine code equals: 202.
+	self assert: response headers contentLength equals: 0.
 	self assert: response entity isNil.
 
 	^ server

--- a/src/Gt4LlmCore/GtLMcpServerExamples.class.st
+++ b/src/Gt4LlmCore/GtLMcpServerExamples.class.st
@@ -34,6 +34,7 @@ GtLMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'prompts/list'} asDictionary.
 	response := server handleRequest: request.
 
@@ -44,6 +45,7 @@ GtLMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'prompts/get'.
 					'params' -> {'invalid' -> 1} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -56,6 +58,7 @@ GtLMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 3.
 					'method' -> 'prompts/get'.
 					'params' -> {'name' -> 'notFound'} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -69,6 +72,7 @@ GtLMcpServerExamples >> serverWithPrompt [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 4.
 					'method' -> 'prompts/get'.
 					'params'
 						-> {'name' -> 'Prompt'.
@@ -102,6 +106,7 @@ GtLMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'resources/list'} asDictionary.
 	response := server handleRequest: request.
 
@@ -111,6 +116,7 @@ GtLMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'resources/read'.
 					'params' -> {'invalid' -> 1} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -123,6 +129,7 @@ GtLMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 3.
 					'method' -> 'resources/read'.
 					'params' -> {'uri' -> 'notFound'} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -136,6 +143,7 @@ GtLMcpServerExamples >> serverWithResource [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 4.
 					'method' -> 'resources/read'.
 					'params'
 						-> {'uri' -> 'resource'}
@@ -187,6 +195,7 @@ GtLMcpServerExamples >> serverWithToolWithBadRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'tools/call'.
 					'params' -> {'invalid' -> 1} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -198,6 +207,7 @@ GtLMcpServerExamples >> serverWithToolWithBadRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'tools/call'.
 					'params' -> {'name' -> 'notFound'} asDictionary} asDictionary.
 	response := server handleRequest: request.
@@ -218,6 +228,7 @@ GtLMcpServerExamples >> serverWithToolWithSuccessfulRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 1.
 					'method' -> 'tools/list'} asDictionary.
 	response := server handleRequest: request.
 	jsonResultTools := (STONJSON fromString: response entity contents)
@@ -227,6 +238,7 @@ GtLMcpServerExamples >> serverWithToolWithSuccessfulRequestAndResponse [
 
 	request := self
 			serverRequestWithEntity: {'jsonrpc' -> '2.0'.
+					'id' -> 2.
 					'method' -> 'tools/call'.
 					'params'
 						-> {'name' -> 'Tool'.


### PR DESCRIPTION
## Summary

Fix MCP Streamable HTTP handling for JSON-RPC notifications so GT4LLM can be registered by Codex as a first-class MCP server.

Previously, GT’s MCP HTTP server returned a JSON-RPC success response for notifications such as:

```json
{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
```

That produced:

```http
HTTP/1.1 200 OK
Content-Type: application/json

{"jsonrpc":"2.0","result":{}}
```

Codex’s MCP client expects MCP Streamable HTTP semantics, so this caused initialization to fail before tools were registered.

## Spec Basis

JSON-RPC 2.0 defines an id-less request as a notification:

> “A Notification is a Request object without an `id` member.”
>
> “The Server MUST NOT reply to a Notification…”

Source: https://www.jsonrpc.org/specification

MCP Streamable HTTP then defines the HTTP response for accepted notifications:

> “If the input is a JSON-RPC response or notification:
> If the server accepts the input, the server MUST return HTTP status code 202 Accepted with no body.”

Source: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports

The MCP lifecycle also shows `notifications/initialized` as id-less:

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/initialized"
}
```

Source: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle

## Changes

- Added JSON-RPC notification detection:
  - `GtLMcpJsonRpc>>isNotification`
  - `GtMcpJsonRpc>>isNotification`

- Changed MCP server response handling so notifications return:
  - `HTTP/1.1 202 Accepted`
  - `Content-Length: 0`
  - zero-byte body

- Kept normal JSON-RPC request behavior unchanged:
  - requests with `id` still return JSON-RPC response bodies
  - tool listing and tool calls continue to work normally

- Updated MCP server examples that expect response data to include `id`, since id-less messages are notifications by spec.

- Added regression examples for:
  - id-less JSON-RPC messages being detected as notifications
  - id-bearing JSON-RPC messages not being notifications
  - `notifications/initialized` returning `202 Accepted` with zero-length response framing

## Verification

Direct HTTP check after rebuild:

```http
HTTP/1.1 202 Accepted
Content-Length: 0
Content-Type: application/octet-stream
```

Normal MCP calls were also verified:

- `initialize` succeeds
- `tools/list` returns GT tools
- `tools/call searchForClasses` returns the expected class list